### PR TITLE
Move short flag into OptionsCli struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,13 @@ pub mod language;
 pub mod printer;
 pub mod utils;
 
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct OptionsCli {
     pub extension: Option<String>,
+    pub short: bool,
 }
 
-pub fn run(paths: Vec<&Path>, opts: OptionsCli) -> Vec<Result<FindResult, Error>> {
+pub fn run(paths: Vec<&Path>, opts: &OptionsCli) -> Vec<Result<FindResult, Error>> {
     paths
         .into_iter()
         .map(|path| resolve_type_and_run(path, &opts))

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -7,6 +7,7 @@ use language::FindResult;
 use printer::Color::*;
 use std::io::Error;
 use std::io::Write;
+use OptionsCli;
 
 enum Color {
     Green,
@@ -15,12 +16,12 @@ enum Color {
     Yellow,
 }
 
-pub struct Printer<W> {
+pub struct Printer<'a, W> {
     pub writer: W,
-    pub short: bool,
+    pub options: &'a OptionsCli,
 }
 
-impl<W> Printer<W>
+impl<'a, W> Printer<'a, W>
 where
     W: Write,
 {
@@ -32,7 +33,7 @@ where
                 }
                 match result.lines.len() {
                     0 => {
-                        if !self.short {
+                        if !self.options.short {
                             self.print_file_name(&result.file_name);
                             self.print_colored(String::from("> No comments found"), White);
                         }
@@ -52,11 +53,11 @@ where
     }
 
     fn error(&mut self, err: &Error) {
-        if !self.short {
+        if !self.options.short {
             self.print_colored_line(Red);
         }
         let msg = format!("Error: {}", err.to_string());
-        if !self.short {
+        if !self.options.short {
             self.print_colored(msg, Red);
             self.print_colored_line(Red);
         }
@@ -64,7 +65,7 @@ where
 
     fn result(&mut self, result: FindResult) {
         let file_name = result.file_name;
-        if !self.short {
+        if !self.options.short {
             self.print_file_name(&file_name);
         }
         result
@@ -82,7 +83,7 @@ where
     }
 
     fn print_comments(&mut self, line_number: u32, file_name: &String) {
-        if !self.short {
+        if !self.options.short {
             let msg = format!("L{}", line_number.to_string());
             self.print_colored(msg, Green);
         } else {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -426,8 +426,8 @@ mod flags {
         let path_python = Path::new("tests/resources/python/with-comments.py");
         let paths = vec![path_javascript, path_python];
 
-        let opts_no_ext = OptionsCli { extension: None };
-        for (i, result) in commentective::run(paths.clone(), opts_no_ext)
+        let opts_no_ext = OptionsCli { extension: None, short: false };
+        for (i, result) in commentective::run(paths.clone(), &opts_no_ext)
             .iter()
             .enumerate()
         {
@@ -450,8 +450,9 @@ mod flags {
 
         let opts_with_ext = OptionsCli {
             extension: Some(str("js")),
+            short: false,
         };
-        for (i, result) in commentective::run(paths, opts_with_ext).iter().enumerate() {
+        for (i, result) in commentective::run(paths, &opts_with_ext).iter().enumerate() {
             assert!(result.is_ok());
 
             if i == 0 {
@@ -489,14 +490,14 @@ mod utils {
     #[test]
     fn resolve_type_with_value() {
         let path = Path::new(EXISTING_FILE);
-        let result = commentective::resolve_type_and_run(path, &OptionsCli { extension: None });
+        let result = commentective::resolve_type_and_run(path, &OptionsCli { extension: None, short: false });
         assert!(result.is_ok());
     }
 
     #[test]
     fn resolve_type_with_err() {
         let path = Path::new(UNSUPPORTED_FILE);
-        let result = commentective::resolve_type_and_run(path, &OptionsCli { extension: None });
+        let result = commentective::resolve_type_and_run(path, &OptionsCli { extension: None, short: false });
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
I would like to keep all options from the CLI in the OptionsCli struct.
That way we can just move around that struct and we don't have to worry
about what specific value is sent to what function - we can just expect
to receive this struct and look for the value we're interested in.

All future flags and options should be added to this struct.