### PR TITLE
Refactor + support golang multiline comments + remove --extension option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ exclude = [
 travis-ci = { repository = "simeg/commentective" }
 codecov = { repository = "simeg/commentective", branch = "master", service = "github" }
 
+[features]
+# this effectively enable the feature `no-color` of colored when testing with
+# `cargo test --feature dumb_terminal`
+dumb_terminal = ["colored/no-color"]
+
 [dependencies]
 clap = "3.0.0-beta.2"
 colored = "2.0.0"

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ run:
 	@RUST_BACKTRACE=1 $(CARGO) run
 
 test:
-	@$(CARGO) test -- --nocapture
+	@$(CARGO) test --features dumb_terminal -- --nocapture

--- a/src/bin/commentective.rs
+++ b/src/bin/commentective.rs
@@ -74,9 +74,7 @@ fn main() {
         language: matches.value_of(OPT_NAME_LANG).map(String::from),
     };
 
-    let printer = Printer {
-        writer: io::stdout(),
-    };
+    let printer = Printer::new(io::stdout());
 
     let mut result = Commentative::new(printer)
         .run(paths, &opts_cli)

--- a/src/bin/commentective.rs
+++ b/src/bin/commentective.rs
@@ -2,100 +2,88 @@
 extern crate clap;
 extern crate colored;
 
-use clap::App;
-use clap::Arg;
-use clap::Values;
 use commentective::printer::Printer;
-use commentective::utils::path::exists_on_filesystem;
+use commentective::utils::path::{exists_on_filesystem, is_file};
 use commentective::utils::string::first_char;
 use commentective::{Commentative, CommentativeOpts};
+
 use std::io;
+
 use std::path::PathBuf;
 
 static ARG_NAME_SHORT: &str = "short";
 static ARG_NAME_CODE: &str = "code";
-static ARG_NAME_LANG: &str = "lang";
-static ARG_NAME_EXTENSION: &str = "extension";
 static ARG_NAME_IGNORE_EMPTY: &str = "ignore-empty";
-static OPT_NAME_FILES: &str = "FILES";
+
+static OPT_NAME_LANG: &str = "lang";
+
+static ARG_NAME_FILES: &str = "FILES";
 
 fn main() {
-    let arg_short = Arg::new(ARG_NAME_SHORT)
+    let arg_short = clap::Arg::new(ARG_NAME_SHORT)
         .short(first_char(ARG_NAME_SHORT))
         .long(ARG_NAME_SHORT)
         .about("Formats output with \"file.ext:line\" without colors. Only outputs files with comments.");
 
-    let arg_code = Arg::new(ARG_NAME_CODE)
+    let arg_code = clap::Arg::new(ARG_NAME_CODE)
         .short(first_char(ARG_NAME_CODE))
         .long(ARG_NAME_CODE)
-        .about("Print the code with comments");
+        .about("Prints the source code line with the comment");
 
-    let arg_lang = Arg::new(ARG_NAME_LANG)
-        .short(first_char(ARG_NAME_LANG))
-        .long(ARG_NAME_LANG)
-        .about("Analyze as this language. Pass the extension, e.g. 'js', 'py', 'sh'")
-        .takes_value(true);
-
-    let arg_extension = Arg::new(ARG_NAME_EXTENSION)
-        .short(first_char(ARG_NAME_EXTENSION))
-        .long(ARG_NAME_EXTENSION)
-        .about("Only analyze files with this extension")
-        .takes_value(true);
-
-    let arg_ignore_empty = Arg::new(ARG_NAME_IGNORE_EMPTY)
+    let arg_ignore_empty = clap::Arg::new(ARG_NAME_IGNORE_EMPTY)
         .short(first_char(ARG_NAME_IGNORE_EMPTY))
         .long(ARG_NAME_IGNORE_EMPTY)
-        .about("Ignore printing files without comments");
+        .about("Ignores printing files without comments");
 
-    let opt_files = Arg::new(OPT_NAME_FILES)
+    let opt_lang = clap::Arg::new(OPT_NAME_LANG)
+        .short(first_char(OPT_NAME_LANG))
+        .long(OPT_NAME_LANG)
+        .about("Analyzes as this language. Pass the extension, e.g. 'js', 'py', 'sh'")
+        .takes_value(true);
+
+    let arg_files = clap::Arg::new(ARG_NAME_FILES)
         .about("Files to analyze")
         .required(true)
         .multiple(true)
         .validator_os(exists_on_filesystem)
+        .validator_os(is_file)
         .index(1);
 
-    let matches = App::new("commentective")
+    let matches = clap::App::new("commentective")
         .author(crate_authors!())
         .version(crate_version!())
         .about("CLI tool to find comments and commented out code")
-        .arg(opt_files)
-        .arg(arg_extension)
+        .arg(arg_files)
         .arg(arg_ignore_empty)
         .arg(arg_short)
         .arg(arg_code)
-        .arg(arg_lang)
+        .arg(opt_lang)
         .get_matches();
 
-    let files: Values = matches.values_of(OPT_NAME_FILES).unwrap();
-    let paths: Vec<PathBuf> = files.map(PathBuf::from).collect();
-
-    let extension: Option<String> = matches.value_of(ARG_NAME_EXTENSION).map(String::from);
-    let language: Option<String> = matches.value_of(ARG_NAME_LANG).map(String::from);
+    // Files are verified to be existing on FS and of type file (not dir)
+    let paths: Vec<PathBuf> = matches
+        .values_of(ARG_NAME_FILES)
+        .unwrap_or_default()
+        .map(PathBuf::from)
+        .collect();
 
     let opts_cli = CommentativeOpts {
-        extension,
         short: matches.is_present(ARG_NAME_SHORT),
         ignore_empty: matches.is_present(ARG_NAME_IGNORE_EMPTY),
         code: matches.is_present(ARG_NAME_CODE),
-        language,
+        language: matches.value_of(OPT_NAME_LANG).map(String::from),
     };
 
-    let mut printer = Printer {
+    let printer = Printer {
         writer: io::stdout(),
-        options: &opts_cli,
     };
 
-    let commentective = Commentative::with_paths(paths);
-
-    let was_successful = commentective
-        .run(&opts_cli)
+    let mut result = Commentative::new(printer)
+        .run(paths, &opts_cli)
         .into_iter()
-        .map(|result| printer.terminal(result))
-        .filter(|result| result.is_err())
-        .count()
-        == 0;
+        .filter(Result::is_err);
 
-    if !was_successful {
+    if result.next().is_some() {
         std::process::exit(1);
     }
 }

--- a/src/language/bash.rs
+++ b/src/language/bash.rs
@@ -1,8 +1,7 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct Bash<F: SimpleFindComments> {
@@ -17,10 +16,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("<<COMMENT")],
-            ends: vec![str("COMMENT")],
+            starts: vec!["<<COMMENT".to_string()],
+            ends: vec!["COMMENT".to_string()],
         };
 
         self.finder
@@ -28,6 +27,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["#"]) && !contains_any_of(line, vec!["#!/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["#"]) && !contains_any_of(comment, vec!["#!/"])
 }

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct C<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct Cpp<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*")],
-            ends: vec![str("*/"), str("/**/")],
+            starts: vec!["/*".to_string()],
+            ends: vec!["*/".to_string(), "/**/".to_string()],
         };
 
         self.finder
@@ -29,8 +28,8 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"])
-        || contains_all(line, vec!["/*", "*/"])
-        || contains_all(line, vec!["/*", "/**/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"])
+        || contains_all(comment, vec!["/*", "*/"])
+        || contains_all(comment, vec!["/*", "/**/"])
 }

--- a/src/language/csharp.rs
+++ b/src/language/csharp.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct CSharp<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/language/css.rs
+++ b/src/language/css.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct CSS<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/language/golang.rs
+++ b/src/language/golang.rs
@@ -1,48 +1,32 @@
-use crate::language::{FindResult, Finder};
-use crate::utils::path::file_name;
+use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_any_of;
 
-use std::fs::File;
-use std::io::{BufRead, BufReader, Error};
+use std::io;
 use std::path::PathBuf;
-use std::vec::Vec;
 
-pub struct Go {
-    _finder: Finder,
+pub struct Go<F: SimpleFindComments> {
+    finder: F,
 }
 
-impl Go {
-    pub fn with_finder(finder: Finder) -> Self {
-        Self { _finder: finder }
+impl<F> Go<F>
+where
+    F: SimpleFindComments,
+{
+    pub fn with_finder(finder: F) -> Self {
+        Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
-        let mut counter = 1; // Lines begin on index 1
-        let mut comments = Vec::<(u32, String)>::new();
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
+        let multi_opts = OptsMultiComments {
+            starts: vec!["/*".to_string()],
+            ends: vec!["*/".to_string()],
+        };
 
-        let file = File::open(&path)?;
-        let file_name = file_name(&path)?;
-
-        for line in BufReader::new(file).lines() {
-            match line {
-                Ok(l) => {
-                    if self.is_comment(&l) {
-                        comments.push((counter, l.to_string()));
-                    }
-                }
-                Err(_) => panic!("Could not read line"),
-            }
-            counter += 1;
-        }
-
-        Ok(FindResult {
-            file_name: file_name.to_string(),
-            lines: comments,
-            ..Default::default()
-        })
+        self.finder
+            .find_comments(path, &multi_opts, is_single_line_comment)
     }
+}
 
-    fn is_comment(&self, line: &str) -> bool {
-        contains_any_of(line, vec!["//"])
-    }
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"])
 }

--- a/src/language/html.rs
+++ b/src/language/html.rs
@@ -1,8 +1,7 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct HTML<F: SimpleFindComments> {
@@ -17,10 +16,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("<!--")],
-            ends: vec![str("-->")],
+            starts: vec!["<!--".to_string()],
+            ends: vec!["-->".to_string()],
         };
 
         self.finder
@@ -28,6 +27,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_all(line, vec!["<!--", "-->"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_all(comment, vec!["<!--", "-->"])
 }

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct Java<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*"), str("/**")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string(), "/**".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct JavaScript<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/language/lua.rs
+++ b/src/language/lua.rs
@@ -1,10 +1,11 @@
-use crate::language::{FindResult, Finder};
+use crate::language::{Comment, FindResult, Finder};
 use crate::utils::path::file_name;
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
 
 use std::fs::File;
-use std::io::{BufRead, BufReader, Error};
+use std::io;
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::vec::Vec;
 
@@ -25,59 +26,56 @@ impl Lua {
         Self { _finder: finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let mut counter = 1; // Lines begin on index 1
-        let mut comments = Vec::<(u32, String)>::new();
+        let mut comments = Vec::<Comment>::new();
         let mut in_multiline = false;
 
         let file = File::open(&path)?;
         let file_name = file_name(&path)?;
 
         for line in BufReader::new(file).lines() {
-            match line {
-                Ok(l) => {
-                    let comment_type = self.get_comment_type(&l);
-                    if in_multiline {
-                        // Ignore everything except MultiLineEnd when in a multiline-comment
-                        comments.push((counter, l.to_string()));
-                        in_multiline = comment_type != LuaCommentType::MultiLineEnd;
-                    } else {
-                        match self.get_comment_type(&l) {
-                            LuaCommentType::SingleLine => comments.push((counter, l.to_string())),
-                            LuaCommentType::MultiLineStart => {
-                                in_multiline = true;
-                                comments.push((counter, l.to_string()));
-                            }
-                            _ => (),
-                        }
+            let content = line.expect("Could not read line");
+            let comment_type = self.get_comment_type(&content);
+            if in_multiline {
+                // Ignore everything except MultiLineEnd when in a multiline-comment
+                comments.push(Comment::new(counter, content.to_string()));
+                in_multiline = comment_type != LuaCommentType::MultiLineEnd;
+            } else {
+                match self.get_comment_type(&content) {
+                    LuaCommentType::SingleLine => {
+                        comments.push(Comment::new(counter, content.to_string()))
                     }
+                    LuaCommentType::MultiLineStart => {
+                        in_multiline = true;
+                        comments.push(Comment::new(counter, content.to_string()));
+                    }
+                    _ => (),
                 }
-                Err(_) => panic!("Could not read line"),
             }
             counter += 1;
         }
 
         Ok(FindResult {
             file_name: file_name.to_string(),
-            lines: comments,
-            ..Default::default()
+            comments,
         })
     }
 
-    fn get_comment_type(&self, line: &str) -> LuaCommentType {
-        if contains_all(line, vec!["--[[", "]]"]) {
+    fn get_comment_type(&self, comment: &str) -> LuaCommentType {
+        if contains_all(comment, vec!["--[[", "]]"]) {
             return LuaCommentType::SingleLine;
         }
 
-        if contains_any_of(line, vec!["]]"]) {
+        if contains_any_of(comment, vec!["]]"]) {
             return LuaCommentType::MultiLineEnd;
         }
 
-        if contains_any_of(line, vec!["--[["]) {
+        if contains_any_of(comment, vec!["--[["]) {
             return LuaCommentType::MultiLineStart;
         }
 
-        if contains_any_of(line, vec!["--"]) {
+        if contains_any_of(comment, vec!["--"]) {
             return LuaCommentType::SingleLine;
         }
 

--- a/src/language/php.rs
+++ b/src/language/php.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct PHP<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*"), str("/**")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string(), "/**".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["#", "//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["#", "//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -1,8 +1,7 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct Ruby<F: SimpleFindComments> {
@@ -17,10 +16,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("=begin")],
-            ends: vec![str("=end")],
+            starts: vec!["=begin".to_string()],
+            ends: vec!["=end".to_string()],
         };
 
         self.finder
@@ -28,6 +27,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["#"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["#"])
 }

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct Rust<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/language/scala.rs
+++ b/src/language/scala.rs
@@ -1,9 +1,8 @@
 use crate::language::{FindResult, OptsMultiComments, SimpleFindComments};
 use crate::utils::string::contains_all;
 use crate::utils::string::contains_any_of;
-use crate::utils::string::str;
 
-use std::io::Error;
+use std::io;
 use std::path::PathBuf;
 
 pub struct Scala<F: SimpleFindComments> {
@@ -18,10 +17,10 @@ where
         Self { finder }
     }
 
-    pub fn find(&self, path: PathBuf) -> Result<FindResult, Error> {
+    pub fn find(&self, path: PathBuf) -> io::Result<FindResult> {
         let multi_opts = OptsMultiComments {
-            starts: vec![str("/*"), str("/**")],
-            ends: vec![str("*/")],
+            starts: vec!["/*".to_string(), "/**".to_string()],
+            ends: vec!["*/".to_string()],
         };
 
         self.finder
@@ -29,6 +28,6 @@ where
     }
 }
 
-fn is_single_line_comment(line: &str) -> bool {
-    contains_any_of(line, vec!["//"]) || contains_all(line, vec!["/*", "*/"])
+fn is_single_line_comment(comment: &str) -> bool {
+    contains_any_of(comment, vec!["//"]) || contains_all(comment, vec!["/*", "*/"])
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -18,13 +18,17 @@ enum Color {
 }
 
 pub struct Printer<W> {
-    pub writer: W,
+    writer: W,
 }
 
 impl<W> Printer<W>
 where
     W: Write,
 {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
     pub fn print_file_name(&mut self, file_name: &str) -> io::Result<()> {
         self.print_colored_line(Yellow)?;
         self.print_colored_text(format!("{} {}", "File:", file_name), Yellow)?;
@@ -83,5 +87,203 @@ where
 
     fn println(&mut self, output: ColoredString) -> io::Result<()> {
         writeln!(&mut self.writer, "{}", output)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #![allow(non_snake_case)]
+
+    use super::colored::Colorize;
+    use crate::language::Comment;
+    use crate::printer::{Color, Printer};
+    use console::Term;
+    use predicates::prelude::predicate::str::contains;
+    use predicates::str::{ends_with, starts_with};
+    use predicates::Predicate;
+    use std::io::{Error, ErrorKind};
+
+    #[test]
+    fn test_printer__print_file_name() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+        let term_width = Term::stdout().size().1 as usize;
+
+        printer.print_file_name("some-file-name").unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+
+        assert!(starts_with(format!("{}\n", "─".repeat(term_width))).eval(&actual));
+        assert!(contains("──\nFile: some-file-name\n──").eval(&actual));
+        assert!(ends_with(format!("{}\n", "─".repeat(term_width))).eval(&actual));
+    }
+
+    #[test]
+    fn test_printer__print_comments__short_and_bold() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+
+        let is_short = true;
+        let is_code = true;
+        printer
+            .print_comments(
+                Comment::new(1, "some-content".to_string()),
+                "some-file-name",
+                is_short,
+                is_code,
+            )
+            .unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+        let expected = "some-file-name:1:some-content\n";
+
+        assert_eq!(actual, expected)
+    }
+
+    #[test]
+    fn test_printer__print_comments__short_but_not_bold() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+
+        let is_short = true;
+        let is_code = false;
+        printer
+            .print_comments(
+                Comment::new(1, "some-content".to_string()),
+                "some-file-name",
+                is_short,
+                is_code,
+            )
+            .unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+        let expected = "some-file-name:1\n";
+
+        assert_eq!(actual, expected)
+    }
+
+    #[test]
+    fn test_printer__print_comments__not_short_but_bold() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+
+        let is_short = false;
+        let is_code = true;
+        printer
+            .print_comments(
+                Comment::new(1, "some-content".to_string()),
+                "some-file-name",
+                is_short,
+                is_code,
+            )
+            .unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+        let expected = "L1 - some-content\n";
+
+        assert_eq!(actual, expected)
+    }
+
+    #[test]
+    fn test_printer__print_comments__not_short_or_bold() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+
+        let is_short = false;
+        let is_code = false;
+        printer
+            .print_comments(
+                Comment::new(1, "some-content".to_string()),
+                "some-file-name",
+                is_short,
+                is_code,
+            )
+            .unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+        let expected = "L1\n";
+
+        assert_eq!(actual, expected)
+    }
+
+    #[test]
+    fn test_printer__print_no_comments_found() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+        let term_width = Term::stdout().size().1 as usize;
+
+        printer
+            .print_no_comments_found("some-file-name".to_string())
+            .unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+
+        assert!(starts_with(format!("{}\n", "─".repeat(term_width))).eval(&actual));
+        assert!(contains("──\nFile: some-file-name\n──").eval(&actual));
+        assert!(
+            ends_with(format!("{}\n> No comments found\n", "─".repeat(term_width))).eval(&actual)
+        );
+    }
+
+    #[test]
+    fn test_printer__print_error() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+        let term_width = Term::stdout().size().1 as usize;
+
+        printer
+            .print_error(&Error::new(ErrorKind::NotFound, "some-error-msg"))
+            .unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+
+        assert!(starts_with(format!("{}\n", "─".repeat(term_width))).eval(&actual));
+        assert!(contains("──\nError: some-error-msg\n──").eval(&actual));
+        assert!(ends_with(format!("{}\n", "─".repeat(term_width))).eval(&actual));
+    }
+
+    #[test]
+    fn test_printer__print_colored_line() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+        let term_width = Term::stdout().size().1 as usize;
+
+        // Color is irrelevant as we're ignoring colors in these tests
+        printer.print_colored_line(Color::Yellow).unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+        let expected = format!("{}\n", "─".repeat(term_width));
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_printer__print_colored_text() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+
+        // Color is irrelevant as we're ignoring colors in these tests
+        printer
+            .print_colored_text("some-text".to_string(), Color::Yellow)
+            .unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+        let expected = "some-text\n";
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_printer__println() {
+        let mut output = Vec::new();
+        let mut printer = Printer::new(&mut output);
+
+        // Color is irrelevant as we're ignoring colors in these tests
+        printer.println("some-text".yellow()).unwrap();
+
+        let actual = String::from_utf8(output).expect("Not UTF-8");
+        let expected = "some-text\n";
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 pub mod path {
     use std::ffi::OsStr;
+    use std::fs::metadata;
     use std::io;
     use std::io::{Error, ErrorKind};
     use std::path::Path;
@@ -9,13 +10,6 @@ pub mod path {
             .map(OsStr::to_str)
             .flatten()
             .ok_or_else(|| Error::new(ErrorKind::InvalidData, "Unable to get file name from path"))
-    }
-
-    pub fn extension(path: &Path) -> io::Result<&str> {
-        path.extension()
-            .map(OsStr::to_str)
-            .flatten()
-            .ok_or_else(|| Error::new(ErrorKind::InvalidData, "Unable to get extension from path"))
     }
 
     pub fn exists_on_filesystem(path: &OsStr) -> Result<(), String> {
@@ -28,6 +22,10 @@ pub mod path {
                     "Unable to determine if file exists on file system",
                 ))
             })
+    }
+
+    pub fn is_file(path: &OsStr) -> Result<(), String> {
+        metadata(path).map(|_| ()).map_err(|e| e.to_string())
     }
 }
 
@@ -45,10 +43,6 @@ pub mod string {
         &found_matches == actual_matches
     }
 
-    pub fn str(input: &str) -> String {
-        String::from(input)
-    }
-
     pub fn first_char(input: &str) -> char {
         input.chars().next().unwrap()
     }
@@ -58,7 +52,7 @@ pub mod string {
 mod test {
     #![allow(non_snake_case)]
 
-    use crate::utils::path::{exists_on_filesystem, extension, file_name};
+    use crate::utils::path::{exists_on_filesystem, file_name};
     use crate::utils::string::{contains_all, contains_any_of, first_char};
     use std::path::Path;
 
@@ -79,25 +73,6 @@ mod test {
         let path = Path::new("");
 
         let actual = file_name(path);
-
-        assert!(actual.is_err())
-    }
-
-    #[test]
-    fn path__extension__ok() {
-        let path = Path::new("dir/dir/some_file.js");
-
-        let actual = extension(path).unwrap();
-        let expected = "js".to_string();
-
-        assert_eq!(actual, expected)
-    }
-
-    #[test]
-    fn path__extension__err() {
-        let path = Path::new("dir/dir/file_without_extension");
-
-        let actual = extension(path);
 
         assert!(actual.is_err())
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -45,40 +45,6 @@ mod cli {
     }
 
     #[test]
-    fn output__only_processes_specified_extension_type() -> TestResult {
-        let mut js_file = tempfile::Builder::new()
-            .prefix("arbitrary")
-            .suffix(".js")
-            .tempfile()?;
-        js_file.write_all(
-            "const someVar = true;\n// comment\n/* multi comment\nanother line\nend line*/"
-                .as_bytes(),
-        )?;
-
-        let mut rs_file = tempfile::Builder::new()
-            .prefix("arbitrary")
-            .suffix(".rs")
-            .tempfile()?;
-        rs_file.write_all(
-            "let some_var = true;\n// comment\n/* multi comment\nanother line\nend line*/"
-                .as_bytes(),
-        )?;
-
-        let mut cmd = Command::cargo_bin("commentective")?;
-        cmd.arg(js_file.path());
-        cmd.arg(rs_file.path());
-        cmd.arg("--extension");
-        cmd.arg("rs");
-
-        let rs_file_name = get_file_name(&mut rs_file);
-        let expected = format!(
-            "────────────────────────────────────────────────────────────────────────────────\nFile: {}\n────────────────────────────────────────────────────────────────────────────────\nL2\nL3\nL4\nL5\n", rs_file_name);
-
-        cmd.assert().success().stdout(diff(expected));
-        Ok(())
-    }
-
-    #[test]
     fn output__with_short_flag() -> TestResult {
         let mut file = tempfile::Builder::new()
             .prefix("arbitrary")

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -41,7 +41,7 @@ mod languages {
         let result = JavaScript::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -66,7 +66,7 @@ mod languages {
         let result = Java::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -89,7 +89,7 @@ mod languages {
         let result = Rust::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod languages {
         let result = Python::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -135,7 +135,7 @@ mod languages {
         let result = CSharp::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -158,7 +158,7 @@ mod languages {
         let result = Bash::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -181,7 +181,7 @@ mod languages {
         let result = PHP::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -204,7 +204,7 @@ mod languages {
         let result = Ruby::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -215,9 +215,9 @@ mod languages {
         assert!(result.is_ok());
 
         let actual = only_line_numbers(result);
-        let expected = [1, 2];
+        let expected = [1, 2, 6, 7, 8, 9];
 
-        assert_eq!(actual.len(), 2);
+        assert_eq!(actual.len(), 6);
         assert_eq!(actual, expected);
     }
 
@@ -227,7 +227,7 @@ mod languages {
         let result = Go::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -250,7 +250,7 @@ mod languages {
         let result = Scala::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -273,7 +273,7 @@ mod languages {
         let result = CSS::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -296,7 +296,7 @@ mod languages {
         let result = HTML::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -319,7 +319,7 @@ mod languages {
         let result = C::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -342,7 +342,7 @@ mod languages {
         let result = Cpp::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert!(result.unwrap().lines.is_empty());
+        assert!(result.unwrap().comments.is_empty());
     }
 
     #[test]
@@ -365,10 +365,15 @@ mod languages {
         let result = Lua::with_finder(Finder {}).find(path);
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().lines.len(), 0);
+        assert_eq!(result.unwrap().comments.len(), 0);
     }
 
-    fn only_line_numbers(result: Result<FindResult, io::Error>) -> Vec<u32> {
-        result.unwrap().lines.into_iter().map(|l| l.0).collect()
+    fn only_line_numbers(result: io::Result<FindResult>) -> Vec<u32> {
+        result
+            .unwrap()
+            .comments
+            .into_iter()
+            .map(|c| c.line_number)
+            .collect()
     }
 }

--- a/tests/resources/golang/with-comments.go
+++ b/tests/resources/golang/with-comments.go
@@ -2,3 +2,8 @@
 // Another comment
 
 package foo
+
+/*
+    Some comments
+    Some comments here too
+*/


### PR DESCRIPTION
* Remove --extension flag for processing only specified extensions. This
  responsibility should not live in this tool. It should just process
  whatever it is fed. Keep it simple stupid :)
* Support golang multi line comments
* Big refactor of entire codebase to make it easier to read and work
  with